### PR TITLE
feat: Add CPU/GPU Device Indicator to GUI

### DIFF
--- a/core_logic.py
+++ b/core_logic.py
@@ -38,6 +38,7 @@ class DictationWorker(QObject):
     transcription_ready = Signal(str)
     error_occurred = Signal(str)
     audio_level = Signal(float)
+    device_changed = Signal(str)
 
     def __init__(self, gui_wid, model_size="large-v3", language="en", vad_enabled=True,
                  silence_threshold=500, silence_duration=0.5, char_delay=0.02,
@@ -113,6 +114,7 @@ class DictationWorker(QObject):
                 self.model = WhisperModel(model_path, device=device, compute_type=compute_type, local_files_only=False)
                 status_msg = f"Model '{self.model_size}' loaded on {device.upper()} ({compute_type})."
                 print(status_msg); self.status_updated.emit(status_msg)
+                self.device_changed.emit("GPU" if device == "cuda" else "CPU")
                 return True
             except Exception as e:
                 if "float16" in str(e) and device == "cuda":
@@ -123,6 +125,7 @@ class DictationWorker(QObject):
                         self.model = WhisperModel(model_path, device="cuda", compute_type=compute_type, local_files_only=False)
                         status_msg = f"Model '{self.model_size}' loaded on CUDA (float32 fallback)."
                         print(status_msg); self.status_updated.emit(status_msg)
+                        self.device_changed.emit("GPU")
                         return True
                     except Exception as e2:
                         print(f"Float32 on CUDA failed: {e2}. Falling back to CPU...")
@@ -132,6 +135,7 @@ class DictationWorker(QObject):
                 self.model = WhisperModel(model_path, device="cpu", compute_type="int8", local_files_only=False)
                 status_msg = f"Model '{self.model_size}' loaded on CPU (int8 fallback)."
                 print(status_msg); self.status_updated.emit(status_msg)
+                self.device_changed.emit("CPU")
                 return True
 
         except Exception as e: 

--- a/main_gui.py
+++ b/main_gui.py
@@ -216,6 +216,10 @@ class OmniDictateApp(QMainWindow):
         self.model_display_label.setObjectName("settingLabel")
         self.model_display_label.setStyleSheet("color: #888; font-size: 10pt; margin-right: 10px;")
 
+        self.device_display_label = QLabel("Device: -")
+        self.device_display_label.setObjectName("deviceLabel")
+        self.device_display_label.setStyleSheet("color: #888; font-size: 10pt; margin-right: 10px;")
+
         self.settings_button = QPushButton()
         self.settings_button.setIcon(self.create_gear_icon())
         self.settings_button.setIconSize(QSize(24, 24))
@@ -227,6 +231,7 @@ class OmniDictateApp(QMainWindow):
         header_layout.addWidget(title)
         header_layout.addStretch()
         header_layout.addWidget(self.model_display_label)
+        header_layout.addWidget(self.device_display_label)
         header_layout.addWidget(self.settings_button)
         layout.addLayout(header_layout)
 
@@ -587,6 +592,14 @@ class OmniDictateApp(QMainWindow):
              self.update_vad_button_style() # Refresh hint text logic
 
     @Slot(str)
+    def update_device_label(self, device_name):
+        self.device_display_label.setText(f"Device: {device_name}")
+        if device_name == "GPU":
+            self.device_display_label.setStyleSheet("color: #30D158; font-size: 10pt; margin-right: 10px; font-weight: bold;")
+        else:
+            self.device_display_label.setStyleSheet("color: #FF9F0A; font-size: 10pt; margin-right: 10px; font-weight: bold;")
+
+    @Slot(str)
     def handle_transcription(self, text):
         current_text = self.transcription_display.toPlainText()
         prefix = "\n" if current_text and not current_text.endswith(('\n', ' ')) else ""
@@ -641,6 +654,7 @@ class OmniDictateApp(QMainWindow):
         self.dictation_worker.transcription_ready.connect(self.handle_transcription)
         self.dictation_worker.error_occurred.connect(self.show_error)
         self.dictation_worker.audio_level.connect(self.update_visualizer) 
+        self.dictation_worker.device_changed.connect(self.update_device_label)
         self.dictation_thread.started.connect(self.dictation_worker.start_processing)
         self.dictation_thread.finished.connect(self.dictation_worker.deleteLater)
         self.dictation_thread.finished.connect(self.dictation_thread.deleteLater)


### PR DESCRIPTION
## Summary
This PR adds a visual indicator to the main application window that explicitly displays whether the Whisper model is running on the CPU or GPU.

Previously, users had to rely on console logs or system performance monitors to confirm if CUDA acceleration was active. Now, the interface provides immediate, color-coded feedback next to the model name.

## Key Changes:
   * **`core_logic.py`**:
       * Added a `device_changed` signal to the `DictationWorker` class.
       * Updated `load_model` to emit "GPU" or "CPU" based on the device determined by `faster-whisper`.
   * **`main_gui.py`**:
       * Added a `device_display_label` to the header layout.
       * Implemented `update_device_label` slot to update the text and color (green for GPU, orange for CPU).