### PR TITLE
Fix garbled typing on Windows: use type() instead of per-char press/release

### DIFF
--- a/core_logic.py
+++ b/core_logic.py
@@ -296,12 +296,9 @@ class DictationWorker(QObject):
                     try:
                         hwnd = ctypes.windll.user32.GetForegroundWindow()
                         if hwnd == self.gui_wid: print("Skipping typing: OmniDictate window active."); continue
-                        for char in text_to_type:
-                            if not self._is_running or self.stop_typing_event.is_set(): break
-                            keyboard_controller.press(char)
-
-                            keyboard_controller.release(char)
-                            time.sleep(self.char_delay)
+                        # PATCH: Use type() instead of per-char press/release
+                        keyboard_controller.type(text_to_type)
+                        time.sleep(0.05)
                     except Exception as e: error_msg = f"Error typing text: {e}"; print(error_msg); self.error_occurred.emit(error_msg)
                 except queue.Empty: continue
                 except Exception as e: error_msg = f"Typing queue error: {e}"; print(error_msg); self.error_occurred.emit(error_msg); time.sleep(0.1)


### PR DESCRIPTION
## Problem
On Windows, the typing mechanism produces garbled/duplicated text because it uses `keyboard_controller.press(char)` + `keyboard_controller.release(char)` for each character individually. This is a known issue (#16, #15).

## Root Cause
pynput's per-character press/release sends individual keydown/keyup events which get mangled by Windows keyboard buffering, especially on CPU (int8) with non-English languages.

## Fix
Replaced the per-character loop with `keyboard_controller.type(text_to_type)` which uses Windows native text input API to type the entire string cleanly.

```diff
- for char in text_to_type:
-     if not self._is_running or self.stop_typing_event.is_set(): break
-     keyboard_controller.press(char)
-     keyboard_controller.release(char)
-     time.sleep(self.char_delay)
+ keyboard_controller.type(text_to_type)
+ time.sleep(0.05)
```

## Testing
- Tested on Samsung Galaxy Book (Intel Core Ultra 7, Windows 11 Pro)
- Swedish dictation with 'small' and 'medium' models
- Text types out cleanly without garbling
- No additional dependencies required